### PR TITLE
Change to use BenchmarkDotNet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin/
 obj/
 .vscode/
+.vs/
+BenchmarkDotNet.Artifacts/

--- a/LazyPerf.csproj
+++ b/LazyPerf.csproj
@@ -5,4 +5,8 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.9" />
+  </ItemGroup>
+
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -1,55 +1,33 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
 
 namespace LazyPerf
 {
-    class Program
+    public class LazyBenchmarks
     {
         static readonly object syncObject = new object();
         static readonly Stopwatch stopwatch = new Stopwatch();
         const int iterations = 10000000;
 
-        static void Main(string[] args)
-        {
-            Console.WriteLine("Lazy<T> Perf Tester");
-            Console.WriteLine("-------------------");
-            Console.WriteLine();
-
-            Time(CreateWithLazyDefaultCtor, nameof(CreateWithLazyDefaultCtor), iterations);
-            Time(CreateWithLazyFactory, nameof(CreateWithLazyFactory), iterations);
-            Time(CreateWithDoubleCheckedLocking, nameof(CreateWithDoubleCheckedLocking), iterations);
-        }
-
-        private static void Time(Action targetMethod, string methodName, int iters)
-        {
-            // Run once so we're not cold
-            targetMethod.Invoke();
-
-            Console.Write($"Running {methodName} {iters} times... ");
-            stopwatch.Start();
-            for (int i = 0; i < iters; i++)
-            {
-                targetMethod.Invoke();
-            }
-            stopwatch.Stop();
-            Console.WriteLine($"{stopwatch.ElapsedMilliseconds} ms");
-            stopwatch.Reset();
-        }
-
-        private static void CreateWithLazyDefaultCtor()
+        [Benchmark]
+        public void CreateWithLazyDefaultCtor()
         { 
             var lazyVar = new Lazy<List<int>>(); 
             var count = lazyVar.Value.Count; 
         }
 
-        private static void CreateWithLazyFactory()
+        [Benchmark]
+        public void CreateWithLazyFactory()
         { 
             var lazyVar = new Lazy<List<int>>(() => new List<int>()); 
             var count = lazyVar.Value.Count; 
         }
 
-        private static void CreateWithDoubleCheckedLocking()
+        [Benchmark]
+        public void CreateWithDoubleCheckedLocking()
         {
             List<int> lazyVar = null;
             if (lazyVar == null)
@@ -65,4 +43,12 @@ namespace LazyPerf
             var count = lazyVar.Count;
         }
     }
-}
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var summary = BenchmarkRunner.Run<LazyBenchmarks>();
+        }
+    }
+    }

--- a/Program.cs
+++ b/Program.cs
@@ -9,8 +9,6 @@ namespace LazyPerf
     public class LazyBenchmarks
     {
         static readonly object syncObject = new object();
-        static readonly Stopwatch stopwatch = new Stopwatch();
-        const int iterations = 10000000;
 
         [Benchmark]
         public void CreateWithLazyDefaultCtor()


### PR DESCRIPTION
With default settings, here's the result from a run

```
// * Summary *

BenchmarkDotNet=v0.10.9, OS=Windows 10.0.16248
Processor=Intel Core i7-4790 CPU 3.60GHz (Haswell), ProcessorCount=8
Frequency=3507499 Hz, Resolution=285.1034 ns, Timer=TSC
.NET Core SDK=2.0.0-preview2-006497
  [Host]     : .NET Core 2.0.0-preview2-25407-01 (Framework 4.6.00001.0), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.0-preview2-25407-01 (Framework 4.6.00001.0), 64bit RyuJIT

                         Method |     Mean |     Error |    StdDev |
------------------------------- |---------:|----------:|----------:|
      CreateWithLazyDefaultCtor | 99.63 ns | 1.9768 ns | 2.4277 ns |
          CreateWithLazyFactory | 41.57 ns | 0.9434 ns | 1.0486 ns |
 CreateWithDoubleCheckedLocking | 20.20 ns | 0.4232 ns | 0.4346 ns |

// * Hints *
Outliers
  LazyBenchmarks.CreateWithDoubleCheckedLocking: Default -> 1 outlier  was  removed

// * Legends *
  Mean   : Arithmetic mean of all measurements
  Error  : Half of 99.9% confidence interval
  StdDev : Standard deviation of all measurements
  1 ns   : 1 Nanosecond (0.000000001 sec)
```